### PR TITLE
Add font family to typography

### DIFF
--- a/src/app/components/Typography/Typography.module.css
+++ b/src/app/components/Typography/Typography.module.css
@@ -6,14 +6,17 @@ p {
 }
 
 .regular {
+  font-family: var(--font-family);
   font-weight: var(--font-weight-regular);
   color: var(--color-text);
 }
 .medium {
+  font-family: var(--font-family);
   font-weight: var(--font-weight-medium);
   color: var(--color-text);
 }
 .action {
+  font-family: var(--font-family);
   font-weight: var(--font-weight-medium);
   color: var(--color-action);
 }


### PR DESCRIPTION
I added the font to typo because the components don't always inherit the font if the font is only in the body in global.css.