### PR TITLE
Add background image to info page

### DIFF
--- a/src/app/pages/Info/Info.module.css
+++ b/src/app/pages/Info/Info.module.css
@@ -1,0 +1,5 @@
+.container {
+  background-image: url('src/app/assets/images/Page.png');
+  height: 100vh;
+  background-size: cover;
+}

--- a/src/app/pages/Info/Info.tsx
+++ b/src/app/pages/Info/Info.tsx
@@ -3,6 +3,7 @@ import CardInfo from '../../components/CardInfo/CardInfo';
 import Header from '../../components/Header/Header';
 import { SPROUTS } from '../../lib/sprouts';
 import { useParams } from 'react-router';
+import style from './Info.module.css';
 
 export default function Info(): JSX.Element {
   const { id }: { id: string } = useParams();
@@ -13,7 +14,7 @@ export default function Info(): JSX.Element {
     console.log('Add');
   }
   return (
-    <main>
+    <main className={style.container}>
       <Header children="Info" onClick={() => history.back()} />
       {filteredSprout.map((sprout) => (
         <CardInfo type="big" {...sprout} onClickAdd={() => handleOnClick()} />


### PR DESCRIPTION
The image is not loaded. I get the following error message.

<img width="474" alt="Screenshot 2021-09-27 at 20 27 10" src="https://user-images.githubusercontent.com/84678921/134965047-ac60a1e1-849d-4a48-999b-2ed579d5ccb3.png">

The image is still loaded in the small cards on the finder page. Is this maybe related to the id in the URL on the info page?

When I refresh the info page, the background image also disappears.

