### PR TITLE
Styling CardInfo Component

### DIFF
--- a/src/app/components/CardInfo/CardInfo.module.css
+++ b/src/app/components/CardInfo/CardInfo.module.css
@@ -61,7 +61,13 @@
 
 .textfield {
   padding: 1rem;
+  display: grid;
   text-align: justify;
+  row-gap: 0.3rem;
+}
+
+.textfieldHeader {
+  text-decoration: underline;
 }
 
 .cardButtons {

--- a/src/app/components/CardInfo/CardInfo.tsx
+++ b/src/app/components/CardInfo/CardInfo.tsx
@@ -58,11 +58,20 @@ export const CardInfo = ({
       </section>
       {type === 'big' && (
         <section className={style.textfield}>
-          <Typography size="s">{textfield}</Typography>
-          <Typography size="m" children="Inhaltsstoffe:" />
-          <Typography size="s">{ingredients}</Typography>
-          <Typography size="m" children="Hinweis:" />
-          <Typography size="s">{note}</Typography>
+          <Typography size="xs">{textfield}</Typography>
+          <Typography
+            className={style.textfieldHeader}
+            size="s"
+            children="Inhaltsstoffe:"
+          />
+          <Typography size="xs">{ingredients}</Typography>
+          <Typography
+            className={style.textfieldHeader}
+            size="s"
+            children="Hinweis:"
+          />
+
+          <Typography size="xs">{note}</Typography>
         </section>
       )}
       <section

--- a/src/app/components/CardInfo/CardInfo.tsx
+++ b/src/app/components/CardInfo/CardInfo.tsx
@@ -65,12 +65,13 @@ export const CardInfo = ({
             children="Inhaltsstoffe:"
           />
           <Typography size="xs">{ingredients}</Typography>
-          <Typography
-            className={style.textfieldHeader}
-            size="s"
-            children="Hinweis:"
-          />
-
+          {note !== undefined && (
+            <Typography
+              className={style.textfieldHeader}
+              size="s"
+              children="Hinweis:"
+            />
+          )}
           <Typography size="xs">{note}</Typography>
         </section>
       )}


### PR DESCRIPTION
Add styling to textfield 
Add conditional to "Hinweis" in textfield. If a sprout does not have a note the textfield header "Hinweis" will not be rendered.
Add grid and text decoration for better legibility